### PR TITLE
[Feat/#37] dependabot과 code quality 작업 디렉토리 차이 이슈 해결

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   code-quality: # git hook 우회 방지
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
     steps:
       - name: 📦 Checkout Repository
         uses: actions/checkout@v4
@@ -27,7 +30,12 @@ jobs:
           cache-dependency-path: "pnpm-lock.yaml"
 
       - name: 📦 Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          if [ "${{ github.event.pull_request.user.login }}" == "dependabot[bot]" ]; then
+            pnpm install
+          else
+            pnpm install --frozen-lockfile
+          fi
 
       - name: 🔍 Run biome check
         run: pnpm run check


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [x] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명
Dependabot PR에서 Code Quality 워크플로우 실패 문제를 해결합니다.

<!-- PR 설명 -->

## 관련된 이슈 넘버
close #37 
<!-- close #1 -->

## ✅ 작업 목록
- [x] GitHub Actions에서 Dependabot 분기 로직 추가
- [x] `working-directory: .` 전역 설정으로 루트 디렉토리 작업 보장
<!-- 이슈 작업한 내용 -->

## MR하기 전에 확인해주세요

- [x] local code lint 검사를 진행하셨나요?
- [x] loca ci test를 진행하셨나요?

## 📚 논의사항
- Dependabot PR에서 의존성 설치 후 lock파일을 커밋해야하는지 논의 필요합니다.
<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions 워크플로우에서 코드 품질 검사 시 PR 작성자가 dependabot[bot]인 경우 의존성 설치 방식이 변경되었습니다.  
  * 모든 실행 단계의 기본 작업 디렉터리가 저장소 루트로 명확히 지정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->